### PR TITLE
Added missing devDependencies for react-bootstrap-slider

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "clean-modules": "rimraf \"node_modules/!(rimraf|.bin)\""
   },
   "devDependencies": {
+    "bootstrap": "^3.3.7",
     "chart.js": "^2.3",
+    "jquery": "^2.2.4",
     "pc-nrfconnect-devdep": "https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git",
     "react-bootstrap-slider": "^1.1.5",
     "react-chartjs-2": "^2.0.5"


### PR DESCRIPTION
Bootstrap and jQuery are required peer dependencies of react-bootstrap-slider, they were missing from package.json.