### PR TITLE
Set correct license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/NordicSemiconductor/pc-nrfconnect-rssi.git"
   },
   "author": "Nordic Semiconductor ASA",
-  "license": "ISC",
+  "license": "SEE LICENSE IN LICENSE",
   "files": [
     "dist/",
     "firmware/",


### PR DESCRIPTION
We have a custom license that does not have an SPDX license identifier. Using `"SEE LICENSE IN <filename>"` as documented on https://docs.npmjs.com/files/package.json#license.