### PR TITLE
Open firmware dialog and program explicitly

### DIFF
--- a/actions/firmwareActions.js
+++ b/actions/firmwareActions.js
@@ -37,15 +37,26 @@
 const firmware = {
     address: 0x2000,
     id: 'rssi-fw-1.0.0',
+    files: {
+        nrf52: './firmware/_build/nrf52832_xxaa.hex',
+    },
 };
 
 export function validateFirmware(serialNumber, { onValid, onInvalid }) {
     return (dispatch, getState, { programming, logger }) => {
         programming.readAddress(serialNumber, firmware.address, firmware.id.length)
-        .then(res => {
-            const data = new Buffer(res).toString();
-            return data === firmware.id ? onValid() : onInvalid();
-        })
-        .catch(err => logger.error(`Error when validating firmware: ${err.message}`));
+            .then(res => {
+                const data = new Buffer(res).toString();
+                return data === firmware.id ? onValid() : onInvalid();
+            })
+            .catch(err => logger.error(`Error when validating firmware: ${err.message}`));
+    };
+}
+
+export function programFirmware(serialNumber, { onSuccess }) {
+    return (dispatch, getState, { programming, logger }) => {
+        programming.programWithHexFile(serialNumber, firmware.files)
+            .then(onSuccess)
+            .catch(err => logger.error(`Error when programming: ${err.message}`));
     };
 }

--- a/actions/firmwareActions.js
+++ b/actions/firmwareActions.js
@@ -1,0 +1,51 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+const firmware = {
+    address: 0x2000,
+    id: 'rssi-fw-1.0.0',
+};
+
+export function validateFirmware(serialNumber, { onValid, onInvalid }) {
+    return (dispatch, getState, { programming, logger }) => {
+        programming.readAddress(serialNumber, firmware.address, firmware.id.length)
+        .then(res => {
+            const data = new Buffer(res).toString();
+            return data === firmware.id ? onValid() : onInvalid();
+        })
+        .catch(err => logger.error(`Error when validating firmware: ${err.message}`));
+    };
+}

--- a/actions/rssiActions.js
+++ b/actions/rssiActions.js
@@ -41,22 +41,6 @@ let maxScans = 30;
 const theRssiData = [];
 const theRssiDataMax = [];
 
-const firmware = {
-    address: 0x2000,
-    id: 'rssi-fw-1.0.0',
-};
-
-function validateFirmware(serialNumber, { onValid, onInvalid }) {
-    return (dispatch, getState, { programming, logger }) => {
-        programming.readAddress(serialNumber, firmware.address, firmware.id.length)
-        .then(res => {
-            const data = new Buffer(res).toString();
-            return data === firmware.id ? onValid() : onInvalid();
-        })
-        .catch(err => logger.error(`Error when validating firmware: ${err.message}`));
-    };
-}
-
 function resetRssiData() {
     theRssiData.splice(0);
     theRssiDataMax.splice(0);
@@ -87,18 +71,6 @@ function rssiData() {
     };
 }
 
-function setDelay(delay) {
-    port.write(`set delay ${delay}\r`);
-}
-
-function setScanRepeatTimes(repeatTimes) {
-    port.write(`set repeat ${repeatTimes}\r`);
-}
-
-function setMaxScans(scans) {
-    maxScans = scans;
-}
-
 function startReading() {
     resetRssiData();
     port.write('start\r');
@@ -110,16 +82,29 @@ function stopReading() {
     resetRssiData();
 }
 
-function scanAdvertisementChannels(enable) {
+
+export function setDelay(delay) {
+    port.write(`set delay ${delay}\r`);
+}
+
+export function setScanRepeatTimes(repeatTimes) {
+    port.write(`set repeat ${repeatTimes}\r`);
+}
+
+export function setMaxScans(scans) {
+    maxScans = scans;
+}
+
+export function scanAdvertisementChannels(enable) {
     port.write(`scan adv ${enable ? 'true' : 'false'}\r`);
     resetRssiData();
 }
 
-function toggleLED() {
+export function toggleLED() {
     port.write('led\r');
 }
 
-function open(serialPort) {
+export function open(serialPort) {
     return (dispatch, getState, { SerialPort, logger }) => {
         port = new SerialPort(serialPort.comName, {
             baudRate: 115200,
@@ -159,7 +144,7 @@ function open(serialPort) {
     };
 }
 
-function close() {
+export function close() {
     return (dispatch, getState, { logger }) => {
         stopReading();
         dispatch(rssiData());
@@ -169,14 +154,3 @@ function close() {
         });
     };
 }
-
-export default {
-    validateFirmware,
-    open,
-    close,
-    setDelay,
-    setMaxScans,
-    setScanRepeatTimes,
-    scanAdvertisementChannels,
-    toggleLED,
-};

--- a/actions/rssiActions.js
+++ b/actions/rssiActions.js
@@ -146,11 +146,13 @@ export function open(serialPort) {
 
 export function close() {
     return (dispatch, getState, { logger }) => {
-        stopReading();
-        dispatch(rssiData());
-        port.close(() => {
-            logger.info('serial port is closed');
-            dispatch(serialPortClosedAction());
-        });
+        if (port && port.isOpen()) {
+            stopReading();
+            dispatch(rssiData());
+            port.close(() => {
+                logger.info('Serial port is closed');
+                dispatch(serialPortClosedAction());
+            });
+        }
     };
 }

--- a/index.jsx
+++ b/index.jsx
@@ -40,7 +40,8 @@ import React from 'react';
 import Chart from './components/Chart';
 import ControlPanel from './components/ControlPanel';
 import reduceApp from './reducers/appReducer';
-import SerialPortActions from './actions/serialPortActions';
+import * as FirmwareActions from './actions/firmwareActions';
+import * as RssiActions from './actions/rssiActions';
 import './resources/css/index.less';
 
 const yRange = {
@@ -94,21 +95,21 @@ export default {
     ),
     mapSidePanelDispatch: (dispatch, props) => ({
         ...props,
-        onDelayChange: delay => dispatch(SerialPortActions.setDelay(delay)),
-        onMaxScansChange: maxScans => dispatch(SerialPortActions.setMaxScans(maxScans)),
+        onDelayChange: delay => dispatch(RssiActions.setDelay(delay)),
+        onMaxScansChange: maxScans => dispatch(RssiActions.setMaxScans(maxScans)),
         onChannelScanRepeatChange: scanRepeat => dispatch(
-            SerialPortActions.setScanRepeatTimes(scanRepeat)),
+            RssiActions.setScanRepeatTimes(scanRepeat)),
         onAnimationDurationChange: animationDuration => dispatch({
             type: 'RSSI_CHANGE_ANIMATION_DURATION',
             animationDuration,
         }),
         onScanAdvertisementsToggle: scanAdvertisementChannels => dispatch(
-            SerialPortActions.scanAdvertisementChannels(scanAdvertisementChannels)),
+            RssiActions.scanAdvertisementChannels(scanAdvertisementChannels)),
         onSeparateFrequencies: separateFrequencies => dispatch({
             type: 'RSSI_SEPARATE_FREQUENCIES',
             separateFrequencies,
         }),
-        onToggleLED: () => dispatch(SerialPortActions.toggleLED()),
+        onToggleLED: () => dispatch(RssiActions.toggleLED()),
     }),
     middleware: store => next => action => {
         if (!action) {
@@ -116,17 +117,17 @@ export default {
         }
         if (action.type === 'FIRMWARE_DIALOG_SHOW') {
             const { port } = action;
-            store.dispatch(SerialPortActions.validateFirmware(port.serialNumber, {
+            store.dispatch(FirmwareActions.validateFirmware(port.serialNumber, {
                 onValid: () => store.dispatch({ type: 'SERIAL_PORT_SELECTED', port }),
                 onInvalid: () => next(action),
             }));
             return;
         }
         if (action.type === 'SERIAL_PORT_SELECTED') {
-            store.dispatch(SerialPortActions.open(action.port));
+            store.dispatch(RssiActions.open(action.port));
         }
         if (action.type === 'SERIAL_PORT_DESELECTED') {
-            store.dispatch(SerialPortActions.close());
+            store.dispatch(RssiActions.close());
         }
         next(action);
     },

--- a/index.jsx
+++ b/index.jsx
@@ -51,11 +51,6 @@ const yRange = {
 };
 
 export default {
-    config: {
-        firmwarePaths: {
-            nrf52: './firmware/_build/nrf52832_xxaa.hex',
-        },
-    },
     decorateMainView: MainView => (
         props => (
             <MainView>
@@ -115,19 +110,24 @@ export default {
         if (!action) {
             return;
         }
-        if (action.type === 'FIRMWARE_DIALOG_SHOW') {
+        if (action.type === 'SERIAL_PORT_SELECTED') {
             const { port } = action;
             store.dispatch(FirmwareActions.validateFirmware(port.serialNumber, {
-                onValid: () => store.dispatch({ type: 'SERIAL_PORT_SELECTED', port }),
-                onInvalid: () => next(action),
+                onValid: () => store.dispatch(RssiActions.open(port)),
+                onInvalid: () => store.dispatch({ type: 'FIRMWARE_DIALOG_SHOW', port }),
             }));
-            return;
-        }
-        if (action.type === 'SERIAL_PORT_SELECTED') {
-            store.dispatch(RssiActions.open(action.port));
         }
         if (action.type === 'SERIAL_PORT_DESELECTED') {
             store.dispatch(RssiActions.close());
+        }
+        if (action.type === 'FIRMWARE_DIALOG_UPDATE_REQUESTED') {
+            const { port } = action;
+            store.dispatch(FirmwareActions.programFirmware(port.serialNumber, {
+                onSuccess: () => {
+                    store.dispatch(RssiActions.open(port));
+                    store.dispatch({ type: 'FIRMWARE_DIALOG_HIDE' });
+                },
+            }));
         }
         next(action);
     },


### PR DESCRIPTION
Now that https://github.com/NordicSemiconductor/pc-nrfconnect-core/pull/52 has been merged in to master, some adjustments are required in the RSSI app.

The firmware dialog is not opened by default anymore. The RSSI app has been modified to listen to `SERIAL_PORT_SELECTED`, and validate firmware when that action is dispatched. If validation is ok, the port is opened. If not, the firmware dialog is opened. Also, instead of specifying the firmware as `config.firmwarePaths`, the RSSI app now calls the programming API when the user confirms firmware update.