### PR TITLE
Pin dependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
     "clean-modules": "rimraf \"node_modules/!(rimraf|.bin)\""
   },
   "devDependencies": {
-    "bootstrap": "^3.3.7",
-    "chart.js": "^2.3",
-    "jquery": "^2.2.4",
+    "bootstrap": "3.3.7",
+    "chart.js": "2.5.0",
+    "jquery": "2.2.4",
     "pc-nrfconnect-devdep": "https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git",
-    "react-bootstrap-slider": "^1.1.5",
-    "react-chartjs-2": "^2.0.5"
+    "react-bootstrap-slider": "1.1.7",
+    "react-chartjs-2": "2.1.0"
   },
   "dependencies": {},
   "engines": {


### PR DESCRIPTION
A new version of chart.js (2.6) has been released. Because we are depending on ^2.3, the newest version that matches 2.x.x will be pulled down on npm install.

The new version of chart.js caused some issues in the RSSI chart, so pinning this dependency on 2.5.0 for now to avoid problems. Also doing the same for our other dependencies.