### PR TITLE
Use pc-nrfjprog-js for programming

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -40,7 +40,7 @@
         "import/no-unresolved": [
             "error",
             {
-                "ignore": [ "nrfconnect/.*", "pc-ble-driver-js", "serialport", "electron" ]
+                "ignore": [ "nrfconnect/.*", "pc-ble-driver-js", "pc-nrfjprog-js", "serialport", "electron" ]
             }
         ],
         "import/extensions": ["off"],

--- a/actions/firmwareActions.js
+++ b/actions/firmwareActions.js
@@ -34,23 +34,61 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { logger } from 'nrfconnect/core';
-import programming from 'nrfconnect/programming';
+import { logger, getAppDir } from 'nrfconnect/core';
+import nrfjprog from 'pc-nrfjprog-js';
 
-const firmware = {
-    address: 0x2000,
-    id: 'rssi-fw-1.0.0',
-    files: {
-        nrf52: './firmware/_build/nrf52832_xxaa.hex',
-    },
-};
+const DEVICE_FAMILY_NRF52 = 1;
+
+const FIRMWARE_ID_ADDRESS = 0x2000;
+const FIRMWARE_ID = 'rssi-fw-1.0.0';
+const FIRMWARE_PATH = `${getAppDir()}/firmware/_build/nrf52832_xxaa.hex`;
+
+function read(serialNumber, address, length) {
+    return new Promise((resolve, reject) => {
+        nrfjprog.read(serialNumber, address, length, (err, contents) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(contents);
+            }
+        });
+    });
+}
+
+function getDeviceInfo(serialNumber) {
+    return new Promise((resolve, reject) => {
+        nrfjprog.getDeviceInfo(serialNumber, (err, deviceInfo) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(deviceInfo);
+            }
+        });
+    });
+}
+
+function program(serialNumber, path) {
+    return new Promise((resolve, reject) => {
+        nrfjprog.program(serialNumber, path, {}, err => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve();
+            }
+        });
+    });
+}
 
 export function validateFirmware(serialNumber, { onValid, onInvalid }) {
-    return () => {
-        programming.readAddress(serialNumber, firmware.address, firmware.id.length)
-            .then(res => {
-                const data = new Buffer(res).toString();
-                return data === firmware.id ? onValid() : onInvalid();
+    return dispatch => {
+        read(serialNumber, FIRMWARE_ID_ADDRESS, FIRMWARE_ID.length)
+            .then(contents => {
+                const data = new Buffer(contents).toString();
+                if (data === FIRMWARE_ID) {
+                    onValid();
+                } else {
+                    onInvalid();
+                }
             })
             .catch(err => logger.error(`Error when validating firmware: ${err.message}`));
     };
@@ -58,7 +96,13 @@ export function validateFirmware(serialNumber, { onValid, onInvalid }) {
 
 export function programFirmware(serialNumber, { onSuccess }) {
     return () => {
-        programming.programWithHexFile(serialNumber, firmware.files)
+        getDeviceInfo(serialNumber)
+            .then(deviceInfo => {
+                if (deviceInfo.family !== DEVICE_FAMILY_NRF52) {
+                    throw new Error(`${serialNumber} is not a nRF52 devkit`);
+                }
+                return program(serialNumber, FIRMWARE_PATH);
+            })
             .then(onSuccess)
             .catch(err => logger.error(`Error when programming: ${err.message}`));
     };

--- a/actions/firmwareActions.js
+++ b/actions/firmwareActions.js
@@ -34,7 +34,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { logger, getAppDir } from 'nrfconnect/core';
+import { getAppDir } from 'nrfconnect/core';
 import nrfjprog from 'pc-nrfjprog-js';
 
 const DEVICE_FAMILY_NRF52 = 1;
@@ -90,12 +90,18 @@ export function validateFirmware(serialNumber, { onValid, onInvalid }) {
                     onInvalid();
                 }
             })
-            .catch(err => logger.error(`Error when validating firmware: ${err.message}`));
+            .catch(err => {
+                dispatch({ type: 'FIRMWARE_DIALOG_HIDE' });
+                dispatch({
+                    type: 'ERROR_DIALOG_SHOW',
+                    message: `Error when validating firmware: ${err.message}`,
+                });
+            });
     };
 }
 
 export function programFirmware(serialNumber, { onSuccess }) {
-    return () => {
+    return dispatch => {
         getDeviceInfo(serialNumber)
             .then(deviceInfo => {
                 if (deviceInfo.family !== DEVICE_FAMILY_NRF52) {
@@ -104,6 +110,12 @@ export function programFirmware(serialNumber, { onSuccess }) {
                 return program(serialNumber, FIRMWARE_PATH);
             })
             .then(onSuccess)
-            .catch(err => logger.error(`Error when programming: ${err.message}`));
+            .catch(err => {
+                dispatch({ type: 'FIRMWARE_DIALOG_HIDE' });
+                dispatch({
+                    type: 'ERROR_DIALOG_SHOW',
+                    message: `Error when programming: ${err.message}`,
+                });
+            });
     };
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,10 +12,10 @@ function createExternals() {
         'react-dom',
         'react-redux',
         'pc-ble-driver-js',
+        'pc-nrfjprog-js',
         'serialport',
         'electron',
         'nrfconnect/core',
-        'nrfconnect/programming',
     ];
 
     // Libs provided by the app at runtime

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,7 @@ function createExternals() {
 }
 
 module.exports = {
-    devtool: isProd ? 'hidden-source-map' : 'inline-eval-cheap-source-map',
+    devtool: isProd ? 'hidden-source-map' : 'cheap-module-source-map',
     entry: './index.jsx',
     output: {
         path: path.join(__dirname, 'dist'),


### PR DESCRIPTION
Replace `nrfconnect/programming` with pc-nrfjprog-js, ref. https://github.com/NordicSemiconductor/pc-nrfconnect-core/pull/96.