### PR TITLE
Don't assume serialport.isOpen is a function (for forwards compatibility)

### DIFF
--- a/actions/rssiActions.js
+++ b/actions/rssiActions.js
@@ -152,7 +152,7 @@ export function open(serialPort) {
 
 export function close() {
     return dispatch => {
-        if (port && port.isOpen && (typeof (port.isOpen) !== 'function' || port.isOpen())) {
+        if (port && (typeof (port.isOpen) === 'function' ? port.isOpen() : port.isOpen)) {
             stopReading();
             dispatch(rssiData());
             port.close(() => {

--- a/actions/rssiActions.js
+++ b/actions/rssiActions.js
@@ -152,7 +152,7 @@ export function open(serialPort) {
 
 export function close() {
     return dispatch => {
-        if (port && port.isOpen()) {
+        if (port && port.isOpen && (typeof (port.isOpen) !== 'function' || port.isOpen())) {
             stopReading();
             dispatch(rssiData());
             port.close(() => {


### PR DESCRIPTION
In `serialport` v4, `port.isOpen` is a `function`; but this behaviour changed in v5, where it's a `boolean`. See https://github.com/node-serialport/node-serialport/pull/899

My local build is running `serialport` v6 due to https://github.com/NordicSemiconductor/pc-nrfconnect-core/pull/155, and we might decide to go ahead with updating `serialport` around. Hence this pull req.