### PR TITLE
Update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "bootstrap": "3.3.7",
     "chart.js": "2.5.0",
     "jquery": "2.2.4",
-    "pc-nrfconnect-devdep": "https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#v1.1.0",
-    "react-bootstrap-slider": "1.1.7",
-    "react-chartjs-2": "2.1.0"
+    "pc-nrfconnect-devdep": "https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#v1.2.1",
+    "react-bootstrap-slider": "2.1.3",
+    "react-chartjs-2": "2.6.1"
   },
   "dependencies": {},
   "engines": {

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
   },
   "devDependencies": {
     "bootstrap": "3.3.7",
-    "chart.js": "2.5.0",
+    "chart.js": "2.7.1",
     "jquery": "2.2.4",
     "pc-nrfconnect-devdep": "https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#v1.2.1",
     "react-bootstrap-slider": "2.1.3",
-    "react-chartjs-2": "2.6.1"
+    "react-chartjs-2": "2.7.0"
   },
   "dependencies": {},
   "engines": {


### PR DESCRIPTION
- updated `react-bootstrap-slider` which fixes React warning about `PropTypes`
- updated *devdep* and *chart.js*
