### PR TITLE
Harden against new serialport version

### DIFF
--- a/lib/actions/rssiActions.js
+++ b/lib/actions/rssiActions.js
@@ -112,12 +112,15 @@ export function toggleLED() {
 }
 
 function openWhenClosed(serialPort) {
+    // Prefer to use the serialport 8 property or fall back to the serialport 7 property
+    const portPath = serialPort.path || serialPort.comName;
+
     return (dispatch, getState) => {
-        port = new SerialPort(serialPort.comName, {
+        port = new SerialPort(portPath, {
             baudRate: 115200,
         }, () => {
-            logger.info(`${serialPort.comName} is open`);
-            dispatch(serialPortOpenedAction(serialPort.comName));
+            logger.info(`${portPath} is open`);
+            dispatch(serialPortOpenedAction(portPath));
 
             (async () => {
                 await scanAdvertisementChannels(false)();


### PR DESCRIPTION
Part of [NCP-2996](https://projecttools.nordicsemi.no/jira/browse/NCP-2996).

This enables the app to run with either serialport 7 (which had comName as a property) or serialport 8 (which moved to the property path and warns when still using comName).