### PR TITLE
Last updates for version 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Nordic Semiconductor ASA",
   "license": "SEE LICENSE IN LICENSE",
   "engines": {
-    "nrfconnect": "^3.4.0"
+    "nrfconnect": "^3.5.0"
   },
   "files": [
     "dist/",
@@ -36,7 +36,7 @@
   "devDependencies": {
     "chart.js": "2.9.3",
     "chartjs-plugin-datalabels": "0.7.0",
-    "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v4.8.4",
+    "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v4.8.14",
     "react": "16.13.1",
     "react-chartjs-2": "2.9.0",
     "react-redux": "7.2.0"

--- a/src/SidePanel/ChannelRange.jsx
+++ b/src/SidePanel/ChannelRange.jsx
@@ -54,7 +54,7 @@ export default () => {
     return (
         <>
             <Form.Label htmlFor={sliderId}>
-                Show BLE channels from{' '}
+                BLE channels from{' '}
                 <NumberInlineInput
                     value={min}
                     range={{ min: bleChannels.min, max }}

--- a/src/SidePanel/LevelRange.jsx
+++ b/src/SidePanel/LevelRange.jsx
@@ -51,20 +51,26 @@ export default () => {
     const min = Math.min(...levelRange);
     const max = Math.max(...levelRange);
 
+    const setNewLevelRangeIfUnequal = (value1, value2) => {
+        if (value1 !== value2) {
+            dispatch(setLevelRange([value1, value2]));
+        }
+    };
+
     return (
         <>
             <Form.Label htmlFor={sliderId}>
                 Show signal levels from{' '}
                 <NumberInlineInput
                     value={-min}
-                    range={{ min: -max, max: -initialLevelRange.min }}
-                    onChange={newMin => dispatch(setLevelRange([-newMin, max]))}
+                    range={{ min: -max + 1, max: -initialLevelRange.min }}
+                    onChange={newMin => setNewLevelRangeIfUnequal(-newMin, max)}
                 />
                 {' '}to{' '}
                 <NumberInlineInput
                     value={-max}
-                    range={{ min: -initialLevelRange.max, max: -min }}
-                    onChange={newMax => dispatch(setLevelRange([min, -newMax]))}
+                    range={{ min: -initialLevelRange.max, max: -min + 1 }}
+                    onChange={newMax => setNewLevelRangeIfUnequal(min, -newMax)}
                 />
                 {' '}dBm
             </Form.Label>
@@ -73,8 +79,8 @@ export default () => {
                 values={levelRange}
                 range={{ min: initialLevelRange.min, max: initialLevelRange.max }}
                 onChange={[
-                    newValue => dispatch(setLevelRange([newValue, levelRange[1]])),
-                    newValue => dispatch(setLevelRange([levelRange[0], newValue])),
+                    newValue => setNewLevelRangeIfUnequal(newValue, levelRange[1]),
+                    newValue => setNewLevelRangeIfUnequal(levelRange[0], newValue),
                 ]}
             />
         </>

--- a/src/SidePanel/LevelRange.jsx
+++ b/src/SidePanel/LevelRange.jsx
@@ -62,25 +62,25 @@ export default () => {
             <Form.Label htmlFor={sliderId}>
                 Signal levels from{' '}
                 <NumberInlineInput
-                    value={-min}
-                    range={{ min: -max + 1, max: -initialLevelRange.min }}
-                    onChange={newMin => setNewLevelRangeIfUnequal(-newMin, max)}
-                />
-                {' '}to{' '}
-                <NumberInlineInput
                     value={-max}
                     range={{ min: -initialLevelRange.max, max: -min + 1 }}
                     onChange={newMax => setNewLevelRangeIfUnequal(min, -newMax)}
+                />
+                {' '}to{' '}
+                <NumberInlineInput
+                    value={-min}
+                    range={{ min: -max + 1, max: -initialLevelRange.min }}
+                    onChange={newMin => setNewLevelRangeIfUnequal(-newMin, max)}
                 />
                 {' '}dBm
             </Form.Label>
             <Slider
                 id={sliderId}
-                values={levelRange}
-                range={{ min: initialLevelRange.min, max: initialLevelRange.max }}
+                values={levelRange.map(v => -v)}
+                range={{ min: -initialLevelRange.max, max: -initialLevelRange.min }}
                 onChange={[
-                    newValue => setNewLevelRangeIfUnequal(newValue, levelRange[1]),
-                    newValue => setNewLevelRangeIfUnequal(levelRange[0], newValue),
+                    newValue => setNewLevelRangeIfUnequal(-newValue, levelRange[1]),
+                    newValue => setNewLevelRangeIfUnequal(levelRange[0], -newValue),
                 ]}
             />
         </>

--- a/src/SidePanel/LevelRange.jsx
+++ b/src/SidePanel/LevelRange.jsx
@@ -60,7 +60,7 @@ export default () => {
     return (
         <>
             <Form.Label htmlFor={sliderId}>
-                Show signal levels from{' '}
+                Signal levels from{' '}
                 <NumberInlineInput
                     value={-min}
                     range={{ min: -max + 1, max: -initialLevelRange.min }}

--- a/src/SidePanel/LevelRange.jsx
+++ b/src/SidePanel/LevelRange.jsx
@@ -56,15 +56,15 @@ export default () => {
             <Form.Label htmlFor={sliderId}>
                 Show signal levels from{' '}
                 <NumberInlineInput
-                    value={min}
-                    range={{ min: initialLevelRange.min, max }}
-                    onChange={newMin => dispatch(setLevelRange([newMin, max]))}
+                    value={-min}
+                    range={{ min: -max, max: -initialLevelRange.min }}
+                    onChange={newMin => dispatch(setLevelRange([-newMin, max]))}
                 />
                 {' '}to{' '}
                 <NumberInlineInput
-                    value={max}
-                    range={{ min, max: initialLevelRange.max }}
-                    onChange={newMax => dispatch(setLevelRange([min, newMax]))}
+                    value={-max}
+                    range={{ min: -initialLevelRange.max, max: -min }}
+                    onChange={newMax => dispatch(setLevelRange([min, -newMax]))}
                 />
                 {' '}dBm
             </Form.Label>

--- a/src/SidePanel/sidepanel.scss
+++ b/src/SidePanel/sidepanel.scss
@@ -6,6 +6,7 @@
 
     h2 {
         margin-top: 6ex;
+        margin-bottom: 3ex;
 
         text-transform: uppercase;
         font-size: 10px;
@@ -15,9 +16,13 @@
         color: $gray-400;
     }
 
-    .form-label,.form-group {
+    h2 + .form-label {
+        margin-top: 0;
+    }
+
+    .form-label {
         margin-top: 1ex;
-        margin-bottom: 0ex;
+        margin-bottom: 0;
     }
 
     .number-inline-input {

--- a/src/actions.js
+++ b/src/actions.js
@@ -148,7 +148,6 @@ export const close = () => async dispatch => {
     } else {
         resetRssiData();
     }
-    dispatch(setRssiData());
     logger.info('Serial port is closed');
     return dispatch(serialPortClosedAction());
 };

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -101,6 +101,7 @@ export default (state = initialState, action) => {
             return {
                 ...state,
                 port: action.portName,
+                isPaused: false,
             };
         case 'RSSI_SERIAL_CLOSED':
             return {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -62,6 +62,9 @@ export default (state = initialState, action) => {
                 isPaused: action.isPaused,
             };
         case 'RSSI_DATA':
+            if (state.isPaused) {
+                return state;
+            }
             return {
                 ...state,
                 data: action.data,
@@ -107,6 +110,9 @@ export default (state = initialState, action) => {
             return {
                 ...state,
                 port: null,
+                isPaused: true,
+                data: [],
+                dataMax: [],
             };
         default:
             return state;


### PR DESCRIPTION
Some more changes to get the RSSI app ready for release:
- Bump the numbers of the required engine and version of `pc-nrfconnect-shared`
- Show negative numbers for signal level in input
- Swap the order of the signal levels now that they are displayed as negative numbers.
- Prevent entering the same lower and upper signal level (which does not make sense and also lead to a strange display)
- Shorten some labels in the side panel so they are usually just a single line
- Fix some margins in the side panel
- Fix that sometimes stale data came in after users close a device
- Updated the screenshot shown on GitHub