### PR TITLE
Use "npm ci" on Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ steps:
     versionSpec: 14
 - script: |
     set -o errexit -o pipefail
-    npm i
+    npm ci
     npm run lint
     npm run build
     npm pack


### PR DESCRIPTION
Because we now have a commited package-lock.json we can use "npm ci" which is faster and safer, since it makes the build fail if `package-lock.json` and `package.json` are out of sync.