### PR TITLE
Fix built bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3747,6 +3747,7 @@
       "version": "2.9.3",
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.3.tgz",
       "integrity": "sha512-+2jlOobSk52c1VU6fzkh3UwqHMdSlgH1xFv9FKMqHiNCpXsGPQa/+81AFa+i3jZ253Mq9aAycPwDjnn1XbRNNw==",
+      "dev": true,
       "requires": {
         "chartjs-color": "^2.1.0",
         "moment": "^2.10.2"
@@ -3756,6 +3757,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.4.1.tgz",
       "integrity": "sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==",
+      "dev": true,
       "requires": {
         "chartjs-color-string": "^0.6.0",
         "color-convert": "^1.9.3"
@@ -3765,6 +3767,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz",
       "integrity": "sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==",
+      "dev": true,
       "requires": {
         "color-name": "^1.0.0"
       }
@@ -3772,7 +3775,8 @@
     "chartjs-plugin-datalabels": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-0.7.0.tgz",
-      "integrity": "sha512-PKVUX14nYhH0wcdCpgOoC39Gbzvn6cZ7O9n+bwc02yKD9FTnJ7/TSrBcfebmolFZp1Rcicr9xbT0a5HUbigS7g=="
+      "integrity": "sha512-PKVUX14nYhH0wcdCpgOoC39Gbzvn6cZ7O9n+bwc02yKD9FTnJ7/TSrBcfebmolFZp1Rcicr9xbT0a5HUbigS7g==",
+      "dev": true
     },
     "cheerio": {
       "version": "1.0.0-rc.3",
@@ -4049,6 +4053,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       },
@@ -4056,14 +4061,16 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
         }
       }
     },
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "color-string": {
       "version": "1.5.4",
@@ -6966,7 +6973,8 @@
     "immer": {
       "version": "7.0.8",
       "resolved": "https://registry.npmjs.org/immer/-/immer-7.0.8.tgz",
-      "integrity": "sha512-XnpIN8PXBBaOD43U8Z17qg6RQiKQYGDGGCIbz1ixmLGwBkSWwmrmx5X7d+hTtXDM8ur7m5OdLE0PiO+y5RB3pw=="
+      "integrity": "sha512-XnpIN8PXBBaOD43U8Z17qg6RQiKQYGDGGCIbz1ixmLGwBkSWwmrmx5X7d+hTtXDM8ur7m5OdLE0PiO+y5RB3pw==",
+      "dev": true
     },
     "immutable": {
       "version": "4.0.0-rc.12",
@@ -9747,7 +9755,8 @@
     "moment": {
       "version": "2.28.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.28.0.tgz",
-      "integrity": "sha512-Z5KOjYmnHyd/ukynmFd/WwyXHd7L4J9vTI/nn5Ap9AVUgaAE15VvQ9MOGmJJygEUklupqIrFnor/tjTwRU+tQw=="
+      "integrity": "sha512-Z5KOjYmnHyd/ukynmFd/WwyXHd7L4J9vTI/nn5Ap9AVUgaAE15VvQ9MOGmJJygEUklupqIrFnor/tjTwRU+tQw==",
+      "dev": true
     },
     "moo": {
       "version": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "main": "dist/bundle.js",
   "prettier": "./node_modules/pc-nrfconnect-shared/config/prettier.config.js",
   "eslintConfig": {
-      "extends" : "./node_modules/pc-nrfconnect-shared/config/eslintrc.json"
+    "extends": "./node_modules/pc-nrfconnect-shared/config/eslintrc.json"
   },
   "scripts": {
     "dev": "nrfconnect-scripts build-watch",
@@ -43,14 +43,13 @@
     "@types/react-dom": "16.9.8",
     "@types/react-redux": "7.1.9",
     "@types/serialport": "8.0.1",
+    "chart.js": "2.9.3",
+    "chartjs-plugin-datalabels": "0.7.0",
+    "immer": "7.0.8",
     "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v4.15.0",
     "react": "16.13.1",
     "react-chartjs-2": "2.9.0",
     "react-redux": "7.2.0"
   },
-  "dependencies": {
-    "chart.js": "2.9.3",
-    "chartjs-plugin-datalabels": "0.7.0",
-    "immer": "7.0.8"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
Because the dependencies were wrongly marked as normal dependencies,
our webpack configuration did not pack them into the bundle. They must
be devDependencies if they are supposed to go into the bundle.