### PR TITLE
use .comName attribute to identify device

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+## 1.3.2-pre1
+
+### Changed
+- Label of graph changed from abbreviated BLE Channel
+- Establish compatibility with nRF Connect for Desktop 3.8
+
 ## 1.3.1 - 2020-12-09
 ### Changed
 - Slight updates to the UI and needed changes for launcher 3.6.1.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-rssi",
-  "version": "1.3.1",
+  "version": "1.3.2-pre1",
   "description": "Demo application for nRF528xx SoC",
   "displayName": "RSSI Viewer",
   "repository": {

--- a/src/Chart/Chart.tsx
+++ b/src/Chart/Chart.tsx
@@ -162,7 +162,8 @@ export default () => {
                                     },
                                     scaleLabel: {
                                         display: true,
-                                        labelString: 'BLE channel',
+                                        labelString:
+                                            'Bluetooth Low Energy Channel',
                                         fontColor: color.label,
                                         fontSize: 14,
                                     },

--- a/src/serialport.ts
+++ b/src/serialport.ts
@@ -73,9 +73,9 @@ export const startReading = (
     onOpened: (portname: string) => void,
     onData: (data: Buffer) => void
 ) => {
-    port = new SerialPort(serialPort.path, { baudRate: 115200 }, () => {
-        logger.info(`${serialPort.path} is open`);
-        onOpened(serialPort.path);
+    port = new SerialPort(serialPort.comName, { baudRate: 115200 }, () => {
+        logger.info(`${serialPort.comName} is open`);
+        onOpened(serialPort.comName);
 
         resumeReading(delay, scanRepeat);
 


### PR DESCRIPTION
on Windows the .path attribute is not trivially mapped to the serialport
and it is therefore more consistent to use the .comName attribute which
is consistent for all platforms.