### PR TITLE
Fix: Outdated description

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "pc-nrfconnect-rssi",
     "version": "1.4.4",
     "displayName": "RSSI Viewer",
-    "description": "Live visualization of RSSI per frequency for nRF52832",
+    "description": "Live visualization of RSSI vs frequency in the 2.4 GHz band",
     "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-rssi",
     "repository": {
         "type": "git",


### PR DESCRIPTION
The description was updated in `apps.json` on the server but not here.