### PR TITLE
doc: rename app + other edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# nRF Connect RSSI Viewer
+# RSSI Viewer app
 
 [![Build Status](https://dev.azure.com/NordicSemiconductor/Wayland/_apis/build/status/NordicSemiconductor.pc-nrfconnect-rssi?branchName=main)](https://dev.azure.com/NordicSemiconductor/Wayland/_build/latest?definitionId=9&branchName=main)
 [![License](https://img.shields.io/badge/license-Modified%20BSD%20License-blue.svg)](LICENSE)
 
-nRF Connect RSSI Viewer is a tool that shows dBm per frequency in the 2400-2480
-MHz range, and allows you to tweak settings like sweep delay and animation
+The RSSI Viewer app in nRF Connect for Desktop is a tool that shows dBm per frequency
+in the 2400-2480 MHz range, and allows you to tweak settings like sweep delay and animation
 duration.
 
 ![screenshot](./doc/docs/screenshots/rssi_viewer_showcase.gif)
 
 ## Installation
 
-nRF Connect RSSI Viewer is installed from nRF Connect from Desktop. For detailed
+The RSSI Viewer app is installed from nRF Connect from Desktop. For detailed
 steps, see
 [Installing nRF Connect for Desktop apps](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/installing_apps.html)
 in the nRF Connect from Desktop documentation.
@@ -19,7 +19,7 @@ in the nRF Connect from Desktop documentation.
 ## Documentation
 
 Read the
-[nRF Connect RSSI Viewer](https://docs.nordicsemi.com/bundle/nrf-connect-rssi-viewer/page/index.html)
+[RSSI Viewer app](https://docs.nordicsemi.com/bundle/nrf-connect-rssi-viewer/page/index.html)
 official documentation, which includes information about the
 [application UI](https://docs.nordicsemi.com/bundle/nrf-connect-rssi-viewer/page/overview.html).
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![Build Status](https://dev.azure.com/NordicSemiconductor/Wayland/_apis/build/status/NordicSemiconductor.pc-nrfconnect-rssi?branchName=main)](https://dev.azure.com/NordicSemiconductor/Wayland/_build/latest?definitionId=9&branchName=main)
 [![License](https://img.shields.io/badge/license-Modified%20BSD%20License-blue.svg)](LICENSE)
 
-The RSSI Viewer app in nRF Connect for Desktop is a tool that shows dBm per frequency
-in the 2400-2480 MHz range, and allows you to tweak settings like sweep delay and animation
-duration.
+The RSSI Viewer app in nRF Connect for Desktop is a tool that shows dBm per
+frequency in the 2400-2480 MHz range, and allows you to tweak settings like
+sweep delay and animation duration.
 
 ![screenshot](./doc/docs/screenshots/rssi_viewer_showcase.gif)
 

--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -1,12 +1,12 @@
-# nRF Connect RSSI Viewer
+# {{app_name}}
 
-nRF Connect RSSI Viewer is a cross-platform tool that shows dBm per frequency in the 2.4 GHz range. It scans the 2400-2480 MHz range, records signal level on the Bluetooth Low Energy channel frequencies, and presents the results.
+The {{app_name}} is a cross-platform tool that shows dBm per frequency in the 2.4 GHz range. It scans the 2400-2480 MHz range, records signal level on the Bluetooth® Low Energy channel frequencies, and presents the results.
 
 You can use the tool with a sniffer device to look for interferers, check how channels are used, and to tweak settings like sweep delay and animation duration.
 
-RSSI Viewer is installed and updated using [nRF Connect for Desktop](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/index.html).
+The {{app_name}} is installed and updated using [nRF Connect for Desktop](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/index.html).
 
 ## Supported devices
 
-Any of the nRF52 Series boards can be used as the sniffer with the RSSI Viewer application.
+Any of the nRF52 Series boards can be used as the sniffer with the {{app_name}}.
 When you [select the device](overview.md#select-device), the tool will reprogram the connected board to act as the sniffer.

--- a/doc/docs/installing.md
+++ b/doc/docs/installing.md
@@ -1,3 +1,3 @@
-# Installing RSSI Viewer app
+# Installing the {{app_name}}
 
 For installation instructions, see [Installing nRF Connect for Desktop apps](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/installing_apps.html) in the nRF Connect for Desktop documentation.

--- a/doc/docs/overview.md
+++ b/doc/docs/overview.md
@@ -1,8 +1,8 @@
 # Overview and user interface
 
-After starting RSSI Viewer, the main application window is displayed.
+After starting the {{app_name}}, the main application window is displayed.
 
-![RSSI Viewer application window](./screenshots/rssi_overview.png "RSSI Viewer application window")
+![{{app_name}} window](./screenshots/rssi_overview.png "{{app_name}} window")
 
 The available options and information change after you **Select Device**.
 
@@ -18,7 +18,7 @@ Dropdown to list the devices attached to the computer. When you select a [suppor
 
 When a device is selected, sniffing in the 2.4 GHz range starts automatically and the side panel options become available.
 
-![RSSI Viewer application window after selecting a device](./screenshots/rssi_viewer_working.gif "RSSI Viewer application window after selecting a device")
+![{{app_name}} window after selecting a device](./screenshots/rssi_viewer_working.gif "{{app_name}} window after selecting a device")
 
 ### Controls
 

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: nRF Connect RSSI Viewer documentation
+site_name: RSSI Viewer app documentation
 site_url:
 use_directory_urls: false
 
@@ -30,7 +30,7 @@ extra_css:
   - stylesheets/style.css
 
 copyright:
-  Copyright &copy; 2023
+  Copyright &copy; 2019-2024
 
 markdown_extensions:
   - abbr
@@ -42,9 +42,6 @@ markdown_extensions:
   - pymdownx.keys
   - pymdownx.tabbed
   - pymdownx.superfences
-  - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
   - toc:
       permalink: true
       toc_depth: 4
@@ -56,8 +53,9 @@ plugins:
 
 extra:
   test: This is a test abbreviation snippet
+  app_name: RSSI Viewer app
 
 nav:
   - Home: index.md
-  - Installing RSSI Viewer app: installing.md
+  - Installing the RSSI Viewer app: installing.md
   - Overview and user interface: overview.md

--- a/doc/zoomin/custom.properties
+++ b/doc/zoomin/custom.properties
@@ -1,3 +1,3 @@
 manual.name=nrf-connect-rssi-viewer
-booktitle=nRF Connect RSSI Viewer
+booktitle=RSSI Viewer app
 shortdesc=Documentation for the nRF Connect RSSI Viewer application.


### PR DESCRIPTION
Dropped nRF Connect from app name.
Updated copyright year.
Removed unused extensions.
Added app_name abbreviation.
NCD-1066.