### PR TITLE
doc: add note about legacy USB drivers

### DIFF
--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -16,6 +16,9 @@ You can use the following Nordic Semiconductor devices as the sniffer with the {
 
 When you [select the device](overview.md#select-device), the tool will reprogram the connected board to act as the sniffer.
 
+!!! note "Note"
+    {{legacy_driver_note}}
+
 ## Application source code
 
 The code of the application is open source and [available on GitHub](https://github.com/NordicSemiconductor/pc-nrfconnect-rssi).

--- a/doc/docs/installing.md
+++ b/doc/docs/installing.md
@@ -1,3 +1,6 @@
 # Installing the {{app_name}}
 
 For installation instructions, see [Installing nRF Connect for Desktop apps](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/installing_apps.html) in the nRF Connect for Desktop documentation.
+
+!!! note "Note"
+    {{legacy_driver_note}}

--- a/doc/docs/overview.md
+++ b/doc/docs/overview.md
@@ -14,6 +14,9 @@ Before a device is selected, the side panel contains the following buttons:
 
 Drop-down to list the devices attached to the computer. When you connect a [supported device](index.md#supported-devices) and select it in this menu, the {{app_name}} programs the device with the correct sniffer firmware, and then connects to one of the available serial ports. Sniffing starts automatically.
 
+!!! note "Note"
+    {{legacy_driver_note}}
+
 ## After selection
 
 When a device is selected, sniffing in the 2.4 GHz range starts automatically and the side panel options become available.

--- a/doc/docs/overview.md
+++ b/doc/docs/overview.md
@@ -14,9 +14,6 @@ Before a device is selected, the side panel contains the following buttons:
 
 Drop-down to list the devices attached to the computer. When you connect a [supported device](index.md#supported-devices) and select it in this menu, the {{app_name}} programs the device with the correct sniffer firmware, and then connects to one of the available serial ports. Sniffing starts automatically.
 
-!!! note "Note"
-    {{legacy_driver_note}}
-
 ## After selection
 
 When a device is selected, sniffing in the 2.4 GHz range starts automatically and the side panel options become available.

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -54,6 +54,7 @@ plugins:
 extra:
   test: This is a test abbreviation snippet
   app_name: RSSI Viewer app
+  legacy_driver_note: Make sure you have installed the [additional requirements](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/download_cfd.html#additional-requirements) for nRF Connect for Desktop. On Windows, SEGGER USB Driver for J-Link is required for correctly detecting the development kits from nRF52 Series, nRF53 Series, and nRF91 Series using [legacy probes](https://kb.segger.com/J-Link_Installer#USB_Driver).
 
 nav:
   - Home: index.md


### PR DESCRIPTION
Added a note with link to NCD requirements about USB J-Link drivers.
NCD-1445.