### PR TITLE
doc: fix link in deprecation note

### DIFF
--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -52,7 +52,7 @@ plugins:
 
 extra:
   test: This is a test abbreviation snippet
-  legacy_driver_note: Make sure you have installed the [additional requirements](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/download_cfd.html#additional-requirements) for nRF Connect for Desktop. On Windows, SEGGER USB Driver for J-Link is required for correctly detecting the development kits from nRF52 Series, nRF53 Series, and nRF91 Series using [legacy probes](https://kb.segger.com/J-Link_Installer#USB_Driver).
+  legacy_driver_note: Make sure you have installed the [additional requirements](https://docs.nordicsemi.com/r/bundle/nrf-connect-for-desktop/page/app/nrf-connect-desktop/download_cfd.html#additional-requirements) for nRF Connect for Desktop. On Windows, SEGGER USB Driver for J-Link is required for correctly detecting the development kits from nRF52 Series, nRF53 Series, and nRF91 Series using [legacy probes](https://kb.segger.com/J-Link_Installer#USB_Driver).
   rssi_deprecation_note: The RSSI Viewer app is deprecated and no longer supported.
 
 nav:


### PR DESCRIPTION
Fixed the link in a note autoincluded through macro, so excluded from the convert_internal_links.ts scope in swtools-app-docs repo.